### PR TITLE
Export the constructor as `XorShift`

### DIFF
--- a/test.js
+++ b/test.js
@@ -120,3 +120,8 @@ test('bad initialization', function (t) {
 
   t.end();
 });
+
+test('constructor export', function (t) {
+  t.equal(xorshift.constructor, xorshift.XorShift);
+  t.end();
+});

--- a/xorshift.js
+++ b/xorshift.js
@@ -108,3 +108,7 @@ module.exports = new XorShift([
   getRandomSeed(),
   getRandomSeed()
 ]);
+
+// Export constructor under its own name so that consumers using ES2015
+// can write `import { XorShift } from 'xorshift'`.
+module.exports.XorShift = XorShift;


### PR DESCRIPTION
This enables consumers using ES2015 to import the class in a more
natural way using:

```js
import { XorShift } from 'xorshift'
```

This also makes it easier to write type declarations for the library for
use with TypeScript.